### PR TITLE
fix: await caught errors to fail the function execution with success

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -39,7 +39,7 @@ app.function('sample_function', async ({ client, inputs, fail, logger }) => {
     });
   } catch (error) {
     logger.error(error);
-    fail({ error: `Failed to handle a function request: ${error}` });
+    await fail({ error: `Failed to handle a function request: ${error}` });
   }
 });
 
@@ -64,7 +64,7 @@ app.action<BlockAction>('sample_button', async ({ body, client, complete, fail, 
   } catch (error) {
     logger.error(error);
     // biome-ignore lint/style/noNonNullAssertion: we know this button comes from a function, so `fail` is available.
-    fail!({ error: `Failed to handle a function request: ${error}` });
+    await fail!({ error: `Failed to handle a function request: ${error}` });
   }
 });
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Summary

This PR awaits asynchronous API calls made within the `fail` step function helper. Updates to the actual `error` messages are left to changes of #27 🤖 

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
